### PR TITLE
Update config_flow.py to fix compatibility with HA 2026.2

### DIFF
--- a/custom_components/homewizard_instant/config_flow.py
+++ b/custom_components/homewizard_instant/config_flow.py
@@ -20,8 +20,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from aiohttp import ClientSession
 from homeassistant.helpers.selector import TextSelector
-from homeassistant.components.dhcp import DhcpServiceInfo
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import CONF_PRODUCT_NAME, CONF_PRODUCT_TYPE, CONF_SERIAL, DOMAIN, LOGGER
 


### PR DESCRIPTION


from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo 
from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo