### PR TITLE
Bump python-homewizard-energy to 10.1.0

### DIFF
--- a/.agent/skills/homeassistant-quality-and-testing/SKILL.md
+++ b/.agent/skills/homeassistant-quality-and-testing/SKILL.md
@@ -152,7 +152,7 @@ rules:
 Statuses: `done`, `todo`, `exempt` (with comment explaining why).
 
 ## Manifest & Metadata
-- Use a lower-bound range for requirements shared with core integrations (e.g., `python-homewizard-energy>=10.1.0`) so they never conflict with the version core pins; bump the lower bound when relying on newer library features.
+- Use a lower-bound range for requirements shared with core integrations (e.g., `python-homewizard-energy>=10.0.1`) so they never conflict with the version core pins; bump the lower bound when relying on newer library features.
 - Set `version`, `config_flow: true`, `iot_class`, and `codeowners`; keep documentation and issue tracker URLs current.
 - For HACS, keep releases/tagging consistent and add `hacs.json` if distribution via HACS.
 

--- a/.agent/skills/homeassistant-quality-and-testing/SKILL.md
+++ b/.agent/skills/homeassistant-quality-and-testing/SKILL.md
@@ -152,7 +152,7 @@ rules:
 Statuses: `done`, `todo`, `exempt` (with comment explaining why).
 
 ## Manifest & Metadata
-- Pin requirements (e.g., `python-homewizard-energy==10.0.1`) to avoid breaking upgrades.
+- Pin requirements (e.g., `python-homewizard-energy==10.1.0`) to avoid breaking upgrades.
 - Set `version`, `config_flow: true`, `iot_class`, and `codeowners`; keep documentation and issue tracker URLs current.
 - For HACS, keep releases/tagging consistent and add `hacs.json` if distribution via HACS.
 

--- a/.agent/skills/homeassistant-quality-and-testing/SKILL.md
+++ b/.agent/skills/homeassistant-quality-and-testing/SKILL.md
@@ -152,7 +152,7 @@ rules:
 Statuses: `done`, `todo`, `exempt` (with comment explaining why).
 
 ## Manifest & Metadata
-- Pin requirements (e.g., `python-homewizard-energy==10.1.0`) to avoid breaking upgrades.
+- Use a lower-bound range for requirements shared with core integrations (e.g., `python-homewizard-energy>=10.1.0`) so they never conflict with the version core pins; bump the lower bound when relying on newer library features.
 - Set `version`, `config_flow: true`, `iot_class`, and `codeowners`; keep documentation and issue tracker URLs current.
 - For HACS, keep releases/tagging consistent and add `hacs.json` if distribution via HACS.
 

--- a/.changeset/bump-homewizard-energy-10-1-0.md
+++ b/.changeset/bump-homewizard-energy-10-1-0.md
@@ -2,4 +2,4 @@
 "ha-homewizard-instant-release-tools": patch
 ---
 
-Relax the python-homewizard-energy requirement to >=10.1.0 so the integration no longer conflicts with Home Assistant core's HomeWizard integration, regardless of the exact version core pins (#7).
+Relax the python-homewizard-energy requirement from an exact pin (==10.0.1) to a range (>=10.0.1) so the integration no longer conflicts with Home Assistant core's HomeWizard integration, regardless of the exact version core pins (#7).

--- a/.changeset/bump-homewizard-energy-10-1-0.md
+++ b/.changeset/bump-homewizard-energy-10-1-0.md
@@ -1,0 +1,5 @@
+---
+"ha-homewizard-instant-release-tools": patch
+---
+
+Bump python-homewizard-energy to 10.1.0 to resolve the dependency conflict with Home Assistant core's HomeWizard integration (#7).

--- a/.changeset/bump-homewizard-energy-10-1-0.md
+++ b/.changeset/bump-homewizard-energy-10-1-0.md
@@ -2,4 +2,4 @@
 "ha-homewizard-instant-release-tools": patch
 ---
 
-Bump python-homewizard-energy to 10.1.0 to resolve the dependency conflict with Home Assistant core's HomeWizard integration (#7).
+Relax the python-homewizard-energy requirement to >=10.1.0 so the integration no longer conflicts with Home Assistant core's HomeWizard integration, regardless of the exact version core pins (#7).

--- a/custom_components/homewizard_instant/manifest.json
+++ b/custom_components/homewizard_instant/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/taurgis/homeassistant-homewizard-instant/issues",
   "loggers": ["homewizard_instant"],
-  "requirements": ["python-homewizard-energy>=10.1.0"],
+  "requirements": ["python-homewizard-energy>=10.0.1"],
   "version": "1.0.2",
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/custom_components/homewizard_instant/manifest.json
+++ b/custom_components/homewizard_instant/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/taurgis/homeassistant-homewizard-instant/issues",
   "loggers": ["homewizard_instant"],
-  "requirements": ["python-homewizard-energy==10.0.1"],
+  "requirements": ["python-homewizard-energy==10.1.0"],
   "version": "1.0.2",
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/custom_components/homewizard_instant/manifest.json
+++ b/custom_components/homewizard_instant/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/taurgis/homeassistant-homewizard-instant/issues",
   "loggers": ["homewizard_instant"],
-  "requirements": ["python-homewizard-energy==10.1.0"],
+  "requirements": ["python-homewizard-energy>=10.1.0"],
   "version": "1.0.2",
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ freezegun>=1.4.0
 ruff>=0.6.9
 mypy>=1.11.2
 pytest-cov
-python-homewizard-energy==10.1.0
+python-homewizard-energy>=10.1.0
 zeroconf
 aiodhcpwatcher
 aiodiscover

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ freezegun>=1.4.0
 ruff>=0.6.9
 mypy>=1.11.2
 pytest-cov
-python-homewizard-energy>=10.1.0
+python-homewizard-energy>=10.0.1
 zeroconf
 aiodhcpwatcher
 aiodiscover

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ freezegun>=1.4.0
 ruff>=0.6.9
 mypy>=1.11.2
 pytest-cov
-python-homewizard-energy==10.0.1
+python-homewizard-energy==10.1.0
 zeroconf
 aiodhcpwatcher
 aiodiscover


### PR DESCRIPTION
Resolves the dependency conflict with Home Assistant core's HomeWizard
integration, which requires python-homewizard-energy==10.1.0. Pinning
10.0.1 here caused the core integration to break after a restart when
both integrations were installed.

Fixes #7

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DfVxe5g5Vmd4uhhE7gKRYo